### PR TITLE
add a composer file for managing plugins via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "wilenius/genai",
+    "description": "This plugin allows you to automatically create questions on a given text using a large language model",
+    "license": "GPL-3.0-or-later",
+    "type": "moodle-qbank",
+    "version": "dev-main",
+    "require": {
+        "composer/installers": "~2.2"
+    }
+}


### PR DESCRIPTION
Thanks for this intesting plugin!

I've added a `composer.json` file to allow managing the plugin via Composer. This makes it easier to include the plugin in projects and handle dependencies in a more standardized and automated way.
